### PR TITLE
Extend max-line-length in flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,2 +1,3 @@
 [flake8]
 exclude = .venv,.git,.tox,dist,doc,*lib/python*,*egg,build
+max-line-length = 93


### PR DESCRIPTION
Set max-line-length to 93

IMHO, it's compromise with the annoying flake message and unlimited freedom